### PR TITLE
Remove jQuery from popup.js

### DIFF
--- a/google-chrome-domain-switcher/popup.html
+++ b/google-chrome-domain-switcher/popup.html
@@ -9,7 +9,6 @@
 		<h4 id="message"></h4>
 		<ul id="options"></ul>
 	</body>
-	<script src="vendor/jquery-1.9.1.min.js"></script>
 	<script src="domain-sets.js"></script>
 	<script src="storage.js"></script>
 	<script src="ui.js"></script>

--- a/google-chrome-domain-switcher/popup.js
+++ b/google-chrome-domain-switcher/popup.js
@@ -1,7 +1,7 @@
 var sets = Storage.load();
 
 if( sets.length === 0 ) {
-	$('#message').text('No Domain Sets Defined');
+	document.querySelector('#message').textContent = 'No Domain Sets Defined';
 }
 else {
 	chrome.tabs.getSelected(null, function (tab){
@@ -13,8 +13,8 @@ else {
 
 		hostname = link.hostname + (("" === link.port) ? "" : ":" + link.port);
 
-		$.each(sets, function (set_i, set) {
-			$.each(set.domains, function (domain_i, domain) {
+		sets.forEach(function (set, set_i) {
+			set.domains.forEach(function (domain, domain_i) {
 				if( hostname === domain ) {
 					found_set = set;
 					return false;
@@ -26,22 +26,26 @@ else {
 		});
 
 		if( found_set ) {
-			$('#message').text(found_set.name);
-			$.each(found_set.domains, function (i, domain) {
+			document.querySelector('#message').textContent = found_set.name;
+			found_set.domains.forEach(function(domain, i) {
 				if( hostname !== domain ) {
-					$('#options').append($('<li/>').append($('<a/>').attr('href', '#').text(domain).data('domain', domain)));
+          var template = '<li><a href="#" data-domain="' + domain + '">' + domain + '</a></li>';
+          document.querySelector('#options').innerHTML += template;
 				}
 			});
-			$('a').on('click', function () {
-				var parts = $(this).data('domain').split(':');
-				link.hostname = parts[0];
-				link.port = parts[1] || '80';
-				chrome.tabs.update(tab.id, {url: link.href});
-				window.close();
-			});
+			var links = document.querySelectorAll('a');
+      for (var i = 0; i < links.length; i++) {
+          links[i].addEventListener('click', function (e) {
+            var parts = this.dataset.domain.split(':');
+            link.hostname = parts[0];
+            link.port = parts[1] || '80';
+            chrome.tabs.update(tab.id, {url: link.href});
+            window.close();
+          });
+			}
 		}
 		else {
-			$('#message').text('No set for: ' + hostname);
+			document.querySelector('#message').textContent = 'No set for: ' + hostname;
 		}
 	});
 }


### PR DESCRIPTION
Related to #4

I pulled out the simple stuff from popup.js into native JS code; but as I started working on options.js I think the code turned out worse (more complex and more brittle... what is the VanillaJS equivalent of `$.closest`?!); so I've left it as is.

A better approach might be to put some structure around the Options page using something like Angular, but that's a separate endeavor I dunno if you want to go down.
